### PR TITLE
Cast last modified date in a datetime

### DIFF
--- a/github/GithubObject.py
+++ b/github/GithubObject.py
@@ -296,11 +296,12 @@ class GithubObject:
         return self._headers.get(Consts.RES_ETAG)  # type: ignore
 
     @property
-    def last_modified(self) -> Optional[str]:
+    def last_modified(self) -> Optional[datetime]:
         """
-        :type: str
+        :type: datetime
         """
-        return self._headers.get(Consts.RES_LAST_MODIFIED)  # type: ignore
+        date_format = "%a, %d %b %Y %H:%M:%S GMT"
+        return datetime.strptime(self._headers.get(Consts.RES_LAST_MODIFIED))  # type: ignore
 
     def get__repr__(self, params: Dict[str, Any]) -> str:
         """


### PR DESCRIPTION
Nearly all dates are returned as `datetime.datetime`
I don't know if all the date format retrieved from headers are consistent, but if it's the case we could get last_modified directly as a datetime like others in the module 